### PR TITLE
meta-moonforge: Migrate documentation to the website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # meta-moonforge
 
-[Moonforge](https://moonforgelinux.org/) is an open-source collection of [Yocto](https://moonforgelinux.org/docs/) layers and build tooling maintained by [Igalia](https://www.igalia.com/). It gives system integrators and product teams a production-ready starting point for building custom, immutable embedded Linux operating systems, without duplicating the integration work that every project ends up doing from scratch.
+[Moonforge](https://moonforgelinux.org/) is an open-source collection of [various Yocto layers](https://moonforgelinux.org/docs/) and build tooling maintained by [Igalia](https://www.igalia.com/). It gives system integrators and product teams a production-ready starting point for building custom, immutable embedded Linux operating systems, without duplicating the integration work that every project ends up doing from scratch.
 
 ## Setup
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,6 @@
 # meta-moonforge
 
-Moonforge is a reliable platform to deploy applications and build products. More concretely:
-
-* A stable Linux distribution.
-* A set of reusable building blocks.
-* A solid base to build derivative products.
-* A collection of the industry best practices.
-
-Built on top of LTS releases of the [Yocto project](https://www.yoctoproject.org/), Moonforge provides essential features like reproducible builds, cross-compilation, generation of compliance reports, and more. Additionally, it provides guidance on how to develop, build and release derivative products following industry best practices.
+[Moonforge](https://moonforgelinux.org/) is an open-source collection of [Yocto](https://moonforgelinux.org/docs/) layers and build tooling maintained by [Igalia](https://www.igalia.com/). It gives system integrators and product teams a production-ready starting point for building custom, immutable embedded Linux operating systems, without duplicating the integration work that every project ends up doing from scratch.
 
 ## Setup
 

--- a/meta-moonforge-distro/README.md
+++ b/meta-moonforge-distro/README.md
@@ -1,34 +1,12 @@
 # meta-moonforge-distro
 
-This layer covers *everything* that should be common to all the OS images built out of this distro layer.
+This is the mandatory base layer that establishes the Moonforge distribution identity, the default partition scheme, and read-only root filesystem.
 
-## What is does
-
-* Builds a new distribution on top of a LTS openembedded-core release.
-* Provides a composable image with features enabled (e.g., read-only-rootfs, overlayfs-etc, etc).
-* Provides recipes bbappend overrides to ensure these settings and features work properly together (e.g., creates an empty `/data` mount point for the persistent partition).
-* Provides an additional recipe to make CVE reports easy for people to read.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-distro.yml
-
-local_conf_header:
-  20_meta-moonforge-distro: |
-    OVERLAYFS_ETC_DEVICE = "/dev/sda3"
-```
-
-Note that, because it's the base Yocto layer, it *must* be used whenever building a new OS image.
-
-See [meta-moonforge-distro](../kas/include/layer/meta-moonforge-distro.yml).
+See: [meta-moonforge-distro on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-distro/)
 
 ## Examples
 
-* See [moonforge-image-base-qemux86-64](../kas/examples/moonforge-image-base-qemux86-64.yml).
+* [moonforge-image-base-qemux86-64](../kas/examples/moonforge-image-base-qemux86-64.yml).
+* [moonforge-image-base-raspberrypi4-64](../kas/examples/moonforge-image-base-raspberrypi4-64.yml).
+* [moonforge-image-base-raspberrypi5](../kas/examples/moonforge-image-base-raspberrypi5.yml).
 

--- a/meta-moonforge-docker/README.md
+++ b/meta-moonforge-docker/README.md
@@ -1,48 +1,12 @@
 # meta-moonforge-docker
 
-This layer adds and configures Docker to be able to run containers.
+This layer adds Docker engine and docker-compose to a Moonforge image, with container storage configured on the persistent data partition.
 
-## What it does
-
-* Provides a custom recipe to configure Docker storage (e.g., to store images on the persistent partition).
-* Extends the base image with Docker recipes and its dependencies.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-docker.yml
-```
-
-See [meta-moonforge-docker](../kas/include/layer/meta-moonforge-docker.yml).
+See: [meta-moonforge-docker on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-docker/)
 
 ## Examples
 
-* See [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
-* See [moonforge-image-full-raspberrypi4-64](../kas/examples/moonforge-image-full-raspberrypi4-64.yml).
-* See [moonforge-image-full-raspberrypi5](../kas/examples/moonforge-image-full-raspberrypi5.yml).
-
-## Testing
-
-Once in the device, test that `docker` is installed:
-
-```sh
-$ docker run -it hello-world
-$ docker run -it ubuntu bash
-```
-
-Additionally, `docker-compose` is also available:
-
-```sh
-$ cat > docker-compose.yml << EOF
-services:
-  hello:
-    image: hello-world
-EOF
-$ docker compose up
-```
+* [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
+* [moonforge-image-full-raspberrypi4-64](../kas/examples/moonforge-image-full-raspberrypi4-64.yml).
+* [moonforge-image-full-raspberrypi5](../kas/examples/moonforge-image-full-raspberrypi5.yml).
 

--- a/meta-moonforge-graphics/README.md
+++ b/meta-moonforge-graphics/README.md
@@ -1,28 +1,12 @@
 # meta-moonforge-graphics
 
-This layer adds and runs a graphical environment for a kiosk-like setting.
+This layer adds the Weston Wayland compositor, configured for kiosk and single-application display environments.
 
-## What it does
-
-* Extends the base image with Weston and other required recipes (e.g., adds gsettings-desktop-schemas).
-* Provides recipes bbappend overrides and base configurations for the Weston compositor, to make it useful for kiosk-like settings (e.g., removes the top panel with default demos).
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-graphics.yml
-```
-
-See [meta-moonforge-graphics](../kas/include/layer/meta-moonforge-graphics.yml).
+See: [meta-moonforge-graphics on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-graphics/)
 
 ## Examples
 
-* See [moonforge-image-alt-qemux86-64.yml](../kas/examples/moonforge-image-alt-qemux86-64.yml).
-* See [moonforge-image-alt-raspberrypi4-64.yml](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
-* See [moonforge-image-alt-raspberrypi5.yml](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
+* [moonforge-image-alt-qemux86-64](../kas/examples/moonforge-image-alt-qemux86-64.yml).
+* [moonforge-image-alt-raspberrypi4-64](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
+* [moonforge-image-alt-raspberrypi5](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
 

--- a/meta-moonforge-podman/README.md
+++ b/meta-moonforge-podman/README.md
@@ -1,28 +1,12 @@
 # meta-moonforge-podman
 
-This layer adds and configures Podman to be able to run containers.
+This layer adds Podman to a Moonforge image, with container storage configured on the persistent data partition and public registry access enabled out of the box.
 
-## What it does
-
-* Provides recipes bbappend overrides to configure Podman storage (e.g., to store images on the persistent partition).
-* Extends the minimal base image with Podman recipes and its dependencies (e.g., ca-certificates to be able to pull images from public registries).
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-podman.yml
-```
-
-See [meta-moonforge-podman](../kas/include/layer/meta-moonforge-podman.yml).
+See: [meta-moonforge-podman on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-podman/)
 
 ## Examples
 
-* See [moonforge-image-alt-qemux86-64](../kas/examples/moonforge-image-alt-qemux86-64.yml).
-* See [moonforge-image-alt-raspberrypi4-64](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
-* See [moonforge-image-alt-raspberrypi5](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
+* [moonforge-image-alt-qemux86-64](../kas/examples/moonforge-image-alt-qemux86-64.yml).
+* [moonforge-image-alt-raspberrypi4-64](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
+* [moonforge-image-alt-raspberrypi5](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
 

--- a/meta-moonforge-qemu/README.md
+++ b/meta-moonforge-qemu/README.md
@@ -1,43 +1,10 @@
 # meta-moonforge-qemu
 
-This layer provides auxiliary assets for QEMU builds.
+This layer adds QEMU x86-64 target support to Moonforge, enabling OS images to be built and tested in a virtual machine without physical hardware.
 
-## What is does
-
-* Extends the base image with recipes, distro and local configurations to build images for qemux86-64.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-qemu.yml
-
-local_conf_header:
-  20_meta-moonforge-qemu: |
-    WKS_FILE = "moonforge-image-base-qemux86-64.wks.in"
-
-machine: qemux86-64
-```
-
-See [meta-moonforge-qemu](../kas/include/layer/meta-moonforge-qemu.yml).
+See: [meta-moonforge-qemu on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-qemu/)
 
 ## Examples
 
-* See [moonforge-image-base-qemux86-64](../kas/examples/moonforge-image-base-qemux86-64.yml).
-
-## Testing
-
-To use `runqemu`:
-
-```sh
-$ cd meta-moonforge
-$ kas-container --runtime-args "--device=/dev/kvm" shell kas/moonforge-image-base-qemux86-64.yml:kas/common/debug.yml
-$ bitbake -c build moonforge-image-base ovmf
-$ bzip2 -df tmp/deploy/images/qemux86-64/moonforge-image-base-qemux86-64.rootfs.wic.bz2
-$ runqemu snapshot kvm nographic slirp ovmf qemux86-64 tmp/deploy/images/qemux86-64/moonforge-image-base-qemux86-64.rootfs.wic
-```
+* [moonforge-image-base-qemux86-64](../kas/examples/moonforge-image-base-qemux86-64.yml).
 

--- a/meta-moonforge-raspberrypi/README.md
+++ b/meta-moonforge-raspberrypi/README.md
@@ -1,44 +1,11 @@
 # meta-moonforge-raspberrypi
 
-This layer adds support for the Raspberry Pi 5 and 4.
+This layer adds board support for the Raspberry Pi 4 and Raspberry Pi 5.
 
-## What it does
-
-* Extends the base image with recipes, distro and local configurations to build images for the Raspberry Pi.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-raspberrypi.yml
-
-local_conf_header:
-  30_meta-moonforge-raspberrypi: |
-    WKS_FILE = "moonforge-image-base-raspberrypi.wks.in"
-
-machine: raspberrypi5
-```
-
-See [meta-moonforge-raspberrypi](../kas/include/layer/meta-moonforge-raspberrypi.yml).
+See: [meta-moonforge-raspberrypi on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-raspberrypi/)
 
 ## Examples
 
-* See [moonforge-image-base-raspberrypi5](../kas/examples/moonforge-image-base-raspberrypi5.yml).
-* See [moonforge-image-base-raspberrypi4-64](../kas/examples/moonforge-image-base-raspberrypi4-64.yml).
-
-## Testing
-
-The built image can be flashed with `bmaptool`:
-
-```sh
-$ bmaptool copy \
-> build/tmp/deploy/images/raspberrypi5/moonforge-image-base-raspberrypi5-0.wic.bz2 \
-> /dev/sdX
-```
-
-Where `/dev/sdX` is the device of the SD card.
+* [moonforge-image-base-raspberrypi5](../kas/examples/moonforge-image-base-raspberrypi5.yml).
+* [moonforge-image-base-raspberrypi4-64](../kas/examples/moonforge-image-base-raspberrypi4-64.yml).
 

--- a/meta-moonforge-rauc-update/README.md
+++ b/meta-moonforge-rauc-update/README.md
@@ -1,51 +1,12 @@
 # meta-moonforge-rauc-update
 
-This layer adds a simple update service for RAUC.
+This layer adds an automated RAUC update client that polls a remote URL for new bundles on a configurable timer.
 
-## What it does
-
-* Provides a custom recipe to trigger RAUC client updates on a timer.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-rauc-update.yml
-
-local_conf_header:
-  40_meta-moonforge-rauc-update: |
-    RAUC_BUNDLE_URL = "http://10.0.2.2:3333/LATEST.raucb"
-    RAUC_FORCE_REBOOT_ON_UPDATE = "1"
-```
-
-See [meta-moonforge-rauc-update](../kas/include/layer/meta-moonforge-rauc-update.yml).
-
-Note *RAUC_FORCE_REBOOT_ON_UPDATE* will force a system reboot, therefore running applications must have inhibitors in place to handle this scenario.
+See: [meta-moonforge-rauc-update on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-rauc-update/).
 
 ## Examples
 
-* See [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
-
-## Testing
-
-Set *RAUC_BUNDLE_URL* in the example kas file to your server host, build the image, and run a web server as follows:
-
-```sh
-$ cd meta-moonforge-rauc-update/backend
-$ cp ../../build/tmp/deploy/images/qemux86-64/moonforge-bundle-base-qemux86-64.raucb data/LATEST.raucb
-$ podman compose up
-$ podman compose down --volumes
-```
-
-On the client, run the service:
-
-```sh
-$ systemctl start rauc-update.service
-$ systemctl status rauc-update.service -l
-$ reboot
-```
+* [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
+* [moonforge-image-full-raspberrypi4-64](../kas/examples/moonforge-image-full-raspberrypi4-64.yml).
+* [moonforge-image-full-raspberrypi5](../kas/examples/moonforge-image-full-raspberrypi5.yml).
 

--- a/meta-moonforge-rauc/README.md
+++ b/meta-moonforge-rauc/README.md
@@ -1,58 +1,12 @@
 # meta-moonforge-rauc
 
-This layer adds RAUC support to manage OS updates.
+This layer adds RAUC A/B over-the-air update support, including bundle signing and demo certificates for local development.
 
-## What it does
-
-* Provides a common recipes to build RAUC bundles.
-* Provides demo certificates to make it easier to sign bundles and test these locally.
-* Extends the base image with recipes for setting up RAUC and its dependencies.
-* Extends the base image with distro and local configurations to build images.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-rauc.yml
-```
-
-See [meta-moonforge-rauc](../kas/include/layer/meta-moonforge-rauc.yml).
-
-Note that, to build images with this layer, additional layers are requires to provide the specific components to enable the target board.
+See: [meta-moonforge-rauc on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-rauc/)
 
 ## Examples
 
-* See [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
-
-## Signing bundles
-
-RAUC signs bundles with an SSL certificate. The default recipe will use the
-certificates included in the Git repository. If you want to use your own
-certificates, you will need to generate them using the `openssl-ca.sh`
-script provided by the meta-rauc layer:
-
-```sh
-$ cd meta-rauc/scripts
-$ ./openssl-ca.sh
-```
-
-The script will create an `openssl-ca` directory where you'll find these
-files:
-
-- `openssl-ca/dev/private/development-1.key.pem`: the private key file
-- `openssl-ca/dev/development-1.cert.pem`: the public certificate file
-- `openssl-ca/dev/ca.cert.pem`: the public keyring file
-
-You should copy those files in a separate location, a then export the
-following environment variables:
-
-```sh
-$ export RAUC_KEY_FILE=/path/to/development-1.key.pem
-$ export RAUC_CERT_FILE=/path/to/development-1.cert.pem
-$ export RAUC_KEYRING_FILE=/path/to/ca.cert.pem
-```
+* [moonforge-image-full-qemux86-64](../kas/examples/moonforge-image-full-qemux86-64.yml).
+* [moonforge-image-full-raspberrypi4-64](../kas/examples/moonforge-image-full-raspberrypi4-64.yml).
+* [moonforge-image-full-raspberrypi5](../kas/examples/moonforge-image-full-raspberrypi5.yml).
 

--- a/meta-moonforge-wpe/README.md
+++ b/meta-moonforge-wpe/README.md
@@ -1,34 +1,12 @@
 # meta-moonforge-wpe
 
-This layer adds WPE Webkit to display a given URL in a kiosk-like setting.
+This layer adds WPE WebKit to display a configurable URL in a fullscreen kiosk window via the Cog browser.
 
-## What it does
-
-* Extends the minimal base image with the WPE related recipes.
-* Provides a custom recipe to launch the Cog browser and display a given URL in a fullscreen window.
-
-## How to use it
-
-To use this layer, include the following kas file:
-
-```yml
-header:
-  version: 16
-  includes:
-    - kas/include/layer/meta-moonforge-wpe.yml
-
-local_conf_header:
-  30_meta-moonforge-wpe: |
-    WAYLAND_COG_LAUNCH_URL = "https://www.igalia.com"
-```
-
-Note that a different URL can be provided by overriding the `WAYLAND_COG_LAUNCH_URL` variable.
-
-See [meta-moonforge-wpe](../kas/include/layer/meta-moonforge-wpe.yml).
+See: [meta-moonforge-wpe on moonforgelinux.org](https://moonforgelinux.org/docs/layers/moonforge-wpe/)
 
 ## Examples
 
-* See [moonforge-image-alt-qemux86-64.yml](../kas/examples/moonforge-image-alt-qemux86-64.yml).
-* See [moonforge-image-alt-raspberrypi4-64.yml](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
-* See [moonforge-image-alt-raspberrypi5.yml](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
+* [moonforge-image-alt-qemux86-64](../kas/examples/moonforge-image-alt-qemux86-64.yml).
+* [moonforge-image-alt-raspberrypi4-64](../kas/examples/moonforge-image-alt-raspberrypi4-64.yml).
+* [moonforge-image-alt-raspberrypi5](../kas/examples/moonforge-image-alt-raspberrypi5.yml).
 


### PR DESCRIPTION
READMEs only include:

* Brief feature summary for the layer
* Examples where the layer is being used
