### PR TITLE
meta-moonforge-rauc-update: Don't wait for all network devices to be …

### DIFF
--- a/meta-moonforge-rauc-update/recipes-core/systemd/systemd/wait-any.conf
+++ b/meta-moonforge-rauc-update/recipes-core/systemd/systemd/wait-any.conf
@@ -1,0 +1,3 @@
+[Service]
+ExecStart=
+ExecStart=/usr/lib/systemd/systemd-networkd-wait-online --any

--- a/meta-moonforge-rauc-update/recipes-core/systemd/systemd_%.bbappend
+++ b/meta-moonforge-rauc-update/recipes-core/systemd/systemd_%.bbappend
@@ -1,0 +1,14 @@
+FILESEXTRAPATHS:prepend := "${THISDIR}/systemd:"
+
+SRC_URI += " \
+    file://wait-any.conf \
+"
+
+do_install:append() {
+	install -d ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d
+	install -m 0644 ${WORKDIR}/wait-any.conf ${D}${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/
+}
+
+FILES:${PN} += " \
+    ${systemd_system_unitdir}/systemd-networkd-wait-online.service.d/wait-any.conf \
+"


### PR DESCRIPTION
…online

By default, it will wait for all links it's aware of to be fully configured or timeout. This creates an unnecessary delay for many services required to be online.

Use the --any flag so that the service will succeed when the fist interface becomes online.

See https://www.freedesktop.org/software/systemd/man/latest/systemd-networkd-wait-online.service.html