### PR TITLE
kas: Bump openembedded-core to latest scarthgap

### DIFF
--- a/kas/include/repo/bitbake.yml
+++ b/kas/include/repo/bitbake.yml
@@ -4,5 +4,5 @@ header:
 repos:
   bitbake:
     url: https://git.openembedded.org/bitbake
-    commit: d3b4c352dd33fca90cd31649eda054b884478739
-    tag: yocto-5.0.17
+    commit: 0880963fea4d91a034e4a6e007d23f98658ab986
+    tag: yocto-5.0.19

--- a/kas/include/repo/meta-openembedded.yml
+++ b/kas/include/repo/meta-openembedded.yml
@@ -4,5 +4,5 @@ header:
 repos:
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
-    commit: 5124ac4a658899158f4a7a2ddf1d2ca931ec7d0e
+    commit: bec755063a8b5da65df626f5749496aadaa4f4bb
     branch: scarthgap

--- a/kas/include/repo/openembedded-core.yml
+++ b/kas/include/repo/openembedded-core.yml
@@ -4,8 +4,8 @@ header:
 repos:
   openembedded-core:
     url: https://git.openembedded.org/openembedded-core
-    commit: 52380df998b3a8fe6a091f8547434a3231320a8e
-    tag: yocto-5.0.17
+    commit: 2814f0962f56c8d1afa4de76d2895ba9b5cb767d
+    tag: yocto-5.0.19
     patches:
       fix-volatile-binds:
         repo: meta-moonforge


### PR DESCRIPTION
I am trying to generate SPDXv3 SBOMs in my Moonforge-based distro, but these are only supported in a newer version of oe-core. This PR just updates to the newest tagged commit, which includes support for SPDXv3.