### PR TITLE
kas: Add buildinfo common fragment

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ This repository contains [example kas files](./kas/examples) for building differ
 Additionally, it contains [auxiliary kas fragments](./kas/common) useful for common tasks while developing locally or in continuous integration environments. For example:
 
 * *kas/common/debug.yml* disables the root password to facilitate testing.
+* *kas/common/buildinfo.yml* adds build information (features, machine, distro) to */etc/buildinfo* in the image.
 * *kas/common/cve.yml* enables the generation of the [Common Vulnerabilities and Exposures](https://www.cve.org/) (CVE) report.
 * *kas/common/sbom.yml* enables the generation of the [Software Bill of Materials](https://www.cisa.gov/sbom) (SBOM) report.
 * *kas/common/throttle.yml* limits the amount of system resources used by bitbake and the build environment, useful when building demanding recipes.

--- a/kas/common/buildinfo.yml
+++ b/kas/common/buildinfo.yml
@@ -1,0 +1,11 @@
+header:
+  version: 16
+
+local_conf_header:
+  20_common-buildinfo: |
+    # Add build information in the image (/etc/buildinfo)
+    INHERIT += "image-buildinfo"
+    IMAGE_BUILDINFO_VARS:append = " DISTRO_NAME IMAGE_BASENAME MACHINE TUNE_PKGARCH"
+    IMAGE_BUILDINFO_VARS:append = " MACHINE_FEATURES DISTRO_FEATURES IMAGE_FEATURES"
+    IMAGE_BUILDINFO_VARS:append = " TUNE_FEATURES TARGET_FPU"
+


### PR DESCRIPTION
## Summary

Adds a new opt-in kas fragment, `kas/common/buildinfo.yml`, that inherits the `image-buildinfo` class and writes a summary of the build configuration to `/etc/buildinfo` inside the image. 

## Justification

Images built from Moonforge currently ship without any embedded record of how
they were produced. When a device is in the field (or an artifact is pulled
from CI/S3), there is no on-image way to tell which machine, distro, and
feature set it was built with. This makes triage and support harder than it
needs to be.

This fragment closes that gap in a way that fits the existing design:

* It is an orthogonal, opt-in `kas/common/*` toggle, composed onto any build
  with `:` just like `debug.yml`, `cve.yml`, `sbom.yml`, and `throttle.yml`.
  Builds that do not include it are unaffected.
* It records only deterministic configuration variables (`DISTRO_NAME`,
  `IMAGE_BASENAME`, `MACHINE`, `TUNE_PKGARCH`, `MACHINE_FEATURES`,
  `DISTRO_FEATURES`, `IMAGE_FEATURES`, `TUNE_FEATURES`, `TARGET_FPU`) on top of
  the class default (`DISTRO`, `DISTRO_VERSION`). Non-reproducible fields such
  as `DATETIME` are deliberately excluded so the image stays byte-for-byte
  reproducible, which is a core Moonforge design goal.
* `image-buildinfo` also appends the layer revisions, which are deterministic
  given the pinned commits in `kas/include/repo/*`, giving a precise, on-image
  provenance record.

## Testing

Compose the fragment onto any example, e.g.:

```sh
kas-container build kas/examples/moonforge-image-base-raspberrypi5.yml:kas/common/buildinfo.yml
```

Then confirm `/etc/buildinfo` is present in the resulting rootfs and lists the
expected configuration and layer revisions.