### PR TITLE
meta-moonforge-graphics: Enable polkit

### DIFF
--- a/kas/include/layer/meta-moonforge-graphics.yml
+++ b/kas/include/layer/meta-moonforge-graphics.yml
@@ -1,13 +1,17 @@
 header:
   version: 16
   includes:
+    - kas/include/repo/meta-openembedded.yml
     - kas/include/layer/meta-moonforge-distro.yml
 
 local_conf_header:
   20_meta-moonforge-graphics: |
-    DISTRO_FEATURES:append = " pam wayland opengl"
+    DISTRO_FEATURES:append = " opengl pam polkit wayland"
 
 repos:
   meta-moonforge:
     layers:
       meta-moonforge-graphics:
+  meta-openembedded:
+    layers:
+      meta-oe:

--- a/meta-moonforge-graphics/recipes-core/images/moonforge-image-base.bbappend
+++ b/meta-moonforge-graphics/recipes-core/images/moonforge-image-base.bbappend
@@ -3,5 +3,6 @@ IMAGE_FEATURES += " \
 "
 
 CORE_IMAGE_EXTRA_INSTALL += " \
+    polkit \
     gsettings-desktop-schemas \
 "


### PR DESCRIPTION
## Summary

Enables [polkit](https://gitlab.freedesktop.org/polkit/polkit) in the graphics layer so that graphical images ship with a system-wide authorization framework. The change adds `polkit` to `DISTRO_FEATURES`, installs the `polkit` package in the image, and makes the graphics layer self-contained by pulling in the meta-oe layer that provides the recipe.

## Justification

Graphical Moonforge devices run a desktop/kiosk session on top of a systemd + D-Bus stack. Several system services these devices rely on (systemd-logind for reboot/poweroff, systemd-timedated/hostnamed, NetworkManager, UDisks2, and RAUC for updates) delegate their authorization decisions to polkit. Without polkit present, those services fall back to
all-or-nothing behavior, which forces privileged operations to run as root instead of being granted to a specific unprivileged session or agent.

Enabling polkit lets a graphical session perform a bounded set of privileged actions (for example rebooting, changing network settings, or triggering an update) under a declarative, build-time policy, following the principle of least privilege. This fits an immutable, read-only-rootfs device well: the policy is fixed and auditable in the image.

The graphics layer previously depended only on openembedded-core recipes. Since
the `polkit` recipe lives in meta-oe (`meta-openembedded/meta-oe/recipes-extended/polkit`), the fragment now includes `kas/include/repo/meta-openembedded.yml` and activates `meta-oe`. 
## Testing

Build an image that includes the graphics layer, e.g.:

```sh
kas-container build kas/examples/moonforge-image-alt-raspberrypi5.yml:kas/common/debug.yml
```

Confirm the image parses (no invalid IMAGE_FEATURES error), the `polkit`
package is present in the rootfs, and `pkaction` lists the expected actions on
the running device.
