### PR TITLE
meta-moonforge-distro: Drop redundant packagegroup-core-boot from base image

### DIFF
--- a/meta-moonforge-distro/recipes-core/images/moonforge-image-base.bb
+++ b/meta-moonforge-distro/recipes-core/images/moonforge-image-base.bb
@@ -7,8 +7,3 @@ SUMMARY = "A single rootfs image composed of one or more moonforge layers"
 LICENSE = "MIT"
 
 inherit moonforge-image
-
-# Set common recipes
-CORE_IMAGE_EXTRA_INSTALL += " \
-    packagegroup-core-boot \
-"


### PR DESCRIPTION
## Summary

`moonforge-image-base.bb` explicitly added `packagegroup-core-boot` to `CORE_IMAGE_EXTRA_INSTALL`, but that packagegroup is already installed unconditionally by `core-image.bbclass`.


This change removes the redundant entry; the resulting image is unchanged.

## Justification: why it is redundant

`moonforge-image-base.bb` inherits `moonforge-image`, which inherits
`core-image` and does **not** override `IMAGE_INSTALL` or
`CORE_IMAGE_BASE_INSTALL`.

`core-image.bbclass` defines:

```
CORE_IMAGE_BASE_INSTALL = '\
    packagegroup-core-boot \
    ...
    ${CORE_IMAGE_EXTRA_INSTALL} \
    '
CORE_IMAGE_EXTRA_INSTALL ?= ""
IMAGE_INSTALL ?= "${CORE_IMAGE_BASE_INSTALL}"
```

So `packagegroup-core-boot` is guaranteed by the class as part of the default
`IMAGE_INSTALL`. The explicit line in the recipe:

```
CORE_IMAGE_EXTRA_INSTALL += " \
    packagegroup-core-boot \
"
```

only appended it a second time to the very same `CORE_IMAGE_BASE_INSTALL`, so `packagegroup-core-boot` was listed **twice** with no functional effect.

## Verification

Run in the kas container (`KAS_CONTAINER_ENGINE=podman`) on `qemux86-64`:

- `bitbake -p moonforge-image-base`; parses with **0 errors**.
- `bitbake -e moonforge-image-base`; `packagegroup-core-boot` is still present
  in the fully-expanded `IMAGE_INSTALL`, now exactly once, sourced from
  `core-image.bbclass` (`CORE_IMAGE_BASE_INSTALL`):

  ```
  IMAGE_INSTALL=" packagegroup-core-boot packagegroup-base-extended ... "
  ```

This confirms the change is a no-op for the produced image (no package added or
removed) and introduces no regression.