### PR TITLE
kas: Add a dropbear SSH server to the debug fragment

### DIFF
--- a/kas/common/debug.yml
+++ b/kas/common/debug.yml
@@ -3,5 +3,7 @@ header:
 
 local_conf_header:
   20_common-debug: |
-    # Enables common debug features
-    EXTRA_IMAGE_FEATURES += "debug-tweaks"
+    # Enables common debug features: debug-tweaks leaves the root password
+    # empty and lets root log in over SSH, so this gives passwordless root
+    # on the console and over the network. Development images only.
+    EXTRA_IMAGE_FEATURES += "debug-tweaks ssh-server-dropbear"


### PR DESCRIPTION
Add the ssh-server-dropbear image feature so a debug image can also be reached over the network. debug-tweaks already relaxes the SSH configuration through ssh_allow_empty_password and ssh_allow_root_login.